### PR TITLE
Add small tests to qualify the image prior to publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,10 @@ x-aliases:
   docker-publish-args: &docker-publish-args
     registry: $DOCKER_REGISTRY
     image: $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
+    after_build:
+      - run:
+          name: Test generated image
+          command: ./test.sh
   filter-only-develop: &filter-only-develop
     filters:
       branches:

--- a/README.md
+++ b/README.md
@@ -37,3 +37,21 @@ workflows:
       - shellcheck/check:
           executor: shellcheck-circleci
 ```
+
+## Development
+
+For development, you can build the image locally using:
+
+```console
+$ ./build.sh
+```
+
+This will build the image and tag it as `shellcheck-circleci:latest`.
+
+To validate the generated image, you can run:
+
+```console
+$ ./test
+```
+
+This will perform some basic tests on the image to see if shellcheck and git are working.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+set -u
+set -o pipefail
+
+cd "$(dirname "$0")"
+
+exec docker build -t shellcheck-circleci .

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -e
+set -u
+set -o pipefail
+
+cd "$(dirname "$0")"
+
+if [ -z "${CIRCLE_PROJECT_REPONAME:-}" ]; then
+	DOCKER_IMAGE="shellcheck-circleci"
+else
+	# When we are running on CircleCI, retrieve the image and tag which we just built.
+	# This is a bit hacky, but we don't have access to the parameters passed to docker-publish/build.
+	DOCKER_IMAGE="$(docker images --format "{{.Repository}}:{{.Tag}}" | grep "/${CIRCLE_PROJECT_REPONAME}:")"
+fi
+
+# Check if shellcheck is present in the image
+if docker run --rm "$DOCKER_IMAGE" shellcheck -V | grep -q 'ShellCheck - shell script analysis tool'; then
+	echo "Shellcheck found." >&2
+else
+	echo "Shellcheck seems to be broken!" >&2
+	exit 1
+fi
+
+# Check if git is present in the image
+if docker run --rm "$DOCKER_IMAGE" git version | grep -q 'git version'; then
+	echo "Git found." >&2
+else
+	echo "Git seems to be broken!" >&2
+	exit 1
+fi
+
+# And, because we can, check if the shellscripts in this repo have any issues
+find . -type f -name '*.sh' | while read -r file; do
+	echo "==== Checking $file ====" >&2
+	docker run -i --rm "$DOCKER_IMAGE" shellcheck --external-sources /dev/stdin < "$file"
+	echo "==== Passed. ====" >&2
+done


### PR DESCRIPTION
We should not just blindly trust the image to work, but instead verify it actually contains a usable version of git and shellcheck.